### PR TITLE
refactor: centralize GitHub CLI command references in skill

### DIFF
--- a/.claude/skills/auto-update-issue-status/SKILL.md
+++ b/.claude/skills/auto-update-issue-status/SKILL.md
@@ -8,17 +8,19 @@ description: Automatically update GitHub Issue status to the next stage (Todo→
 ## Instructions
 Provide clear, step-by-step guidance for Claude.
 
+**Important**: All GitHub CLI commands used in this skill are defined in `.claude/skills/gh-commands.md`. Refer to that file for command syntax and usage examples.
+
 1. **Extract Information from URL**: Given a GitHub Issue URL (e.g., `https://github.com/Tasup/Tasup/issues/5`), extract the owner, repository name, and issue number.
 
-2. **Get Project Information**: Use the command `gh project list --owner OWNER --format json` to retrieve the list of projects. Extract the first project's ID and number from the JSON output.
+2. **Get Project Information**: Refer to `.claude/skills/gh-commands.md` for the "Get project information" command. Execute it to retrieve the list of projects and extract the first project's ID and number from the JSON output.
 
 3. **Get Project Item ID and Current Status**:
-   - Use the command `gh project item-list PROJECT_NUMBER --owner OWNER --format json --limit 100` to retrieve all project items.
+   - Refer to `.claude/skills/gh-commands.md` for the "Get project item ID" command.
    - Find the item that matches the issue number and extract its ID.
    - Parse the item's `fieldValues` to find the current status value.
    - If the issue is not found in the project items, return an error: "Issue is not linked to any project."
 
-4. **Get Field Information**: Use the command `gh project field-list PROJECT_NUMBER --owner OWNER --format json` to retrieve the project fields. Find the "Status" field and extract:
+4. **Get Field Information**: Refer to `.claude/skills/gh-commands.md` for the "Get field information" command. Find the "Status" field and extract:
    - Field ID
    - All status option IDs and their names (Todo, In Progress, Done)
    - If the Status field doesn't exist, return an error: "Status field not found in project."
@@ -29,7 +31,7 @@ Provide clear, step-by-step guidance for Claude.
    - If current status is "Done", skip the update and return a message: "Issue is already in Done status. No update needed."
    - If current status is not one of the expected values, return an error: "Unknown current status: [STATUS_NAME]"
 
-6. **Update Issue Status**: Use the command `gh project item-edit --id ITEM_ID --project-id PROJECT_ID --field-id FIELD_ID --single-select-option-id NEXT_OPTION_ID` to update the status to the next stage. Replace the placeholders with the values obtained in previous steps.
+6. **Update Issue Status**: Refer to `.claude/skills/gh-commands.md` for the "Update issue status" command. Execute it with the values obtained in previous steps to update the status to the next stage.
 
 7. **Handle Errors**: Ensure to handle potential errors, such as:
    - Invalid URLs
@@ -41,35 +43,10 @@ Provide clear, step-by-step guidance for Claude.
    - Unknown or unexpected status values
    Provide clear error messages for each scenario.
 
-8. **Confirm Success**: After successfully updating the status, verify the update by running `gh issue view ISSUE_NUMBER --json projectItems` and confirm with a success message that includes:
+8. **Confirm Success**: Refer to `.claude/skills/gh-commands.md` for the "Verify update" command. After successfully updating the status, verify the update and confirm with a success message that includes:
    - The previous status
    - The new status
    - Example: "Successfully updated issue #5 from 'Todo' to 'In Progress'"
-
-## Example Commands
-```bash
-# Step 2: Get project information
-gh project list --owner Tasup --format json
-
-# Step 3: Get project item ID and parse current status
-gh project item-list 1 --owner Tasup --format json --limit 100
-
-# Example of parsing current status from JSON output:
-# Look for the item matching your issue number, then find the Status field value
-
-# Step 4: Get field information (all status options)
-gh project field-list 1 --owner Tasup --format json
-
-# Example output processing:
-# Find the field with name "Status"
-# Extract field ID and all option IDs for: Todo, In Progress, Done
-
-# Step 6: Update status (example transitioning from Todo to In Progress)
-gh project item-edit --id PVTI_xxx --project-id PVT_xxx --field-id PVTSSF_xxx --single-select-option-id 47fc9ee4
-
-# Step 8: Verify update
-gh issue view 5 --json projectItems
-```
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- Refactored `auto-update-issue-status` skill to reference `gh-commands.md` for all GitHub CLI commands
- Removed embedded command examples from SKILL.md in favor of references to centralized documentation
- This improves maintainability by establishing a single source of truth for command syntax

## Test plan

- [ ] Verify the skill still functions correctly with the updated references
- [ ] Confirm all referenced commands exist in `gh-commands.md`
- [ ] Test the auto-update workflow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)