### PR TITLE
READMEのですます調を体言止めに修正

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,9 @@
       "Bash(git push:*)",
       "Bash(tree:*)",
       "Skill(update-issue-status-from-todo-to-in-progress)",
-      "Skill(auto-update-issue-status)"
+      "Skill(auto-update-issue-status)",
+      "Bash(cat:*)",
+      "Bash(git checkout:*)"
     ],
     "deny": [],
     "ask": []

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Tasupは、GitHub Projects V2とGitHub Issuesの統合を管理するためのClaude Code設定リポジトリです。主にGitHub CLIコマンドを使用して、Issueのステータスを自動的に更新するワークフローを提供します。
+Tasupは、GitHub Projects V2とGitHub Issuesの統合を管理するためのClaude Code設定リポジトリ。主にGitHub CLIコマンドを使用して、Issueのステータスを自動的に更新するワークフローを提供。
 
 ## Common Commands
 
@@ -40,13 +40,13 @@ git push
 
 ### Claude Code Custom Commands & Skills
 
-このリポジトリは以下のClaude Code拡張機能を提供します：
+このリポジトリは以下のClaude Code拡張機能を提供：
 
 #### Slash Command: `/issue-progress`
 
 Location: `.claude/commands/issue-progress.md`
 
-GitHub IssueのステータスをGitHub Projects V2で「In progress」に更新するコマンド。GraphQL APIとgh CLIを組み合わせて、以下のプロセスで動作します：
+GitHub IssueのステータスをGitHub Projects V2で「In progress」に更新するコマンド。GraphQL APIとgh CLIを組み合わせて、以下のプロセスで動作：
 
 1. Issue URLから情報を抽出
 2. GraphQL APIでプロジェクト情報を取得（item_id, project_id, field_id, option_id）
@@ -59,11 +59,11 @@ GitHub IssueのステータスをGitHub Projects V2で「In progress」に更新
 
 Location: `.claude/skills/update-issue-status-from-todo-to-in-progress/SKILL.md`
 
-GitHub IssueのステータスをTODOからIN_PROGRESSに更新するスキル。7ステップのプロセスで実装されており、エラーハンドリングと検証を含みます。
+GitHub IssueのステータスをTODOからIN_PROGRESSに更新するスキル。7ステップのプロセスで実装されており、エラーハンドリングと検証を含む。
 
 ### 承認済みコマンド
 
-`.claude/settings.local.json`で以下のコマンドが自動承認されています：
+`.claude/settings.local.json`で以下のコマンドを自動承認：
 
 - `Bash(sed:*)` - テキスト処理
 - `Bash(gh:*)` - GitHub CLI操作
@@ -73,7 +73,7 @@ GitHub IssueのステータスをTODOからIN_PROGRESSに更新するスキル�
 
 ## GitHub Projects V2 Integration
 
-このリポジトリの主な目的は、GitHub Projects V2のステータス管理を自動化することです。
+このリポジトリの主な目的は、GitHub Projects V2のステータス管理を自動化。
 
 ### 必要な前提条件
 


### PR DESCRIPTION
## Summary

CLAUDE.md内の「です・ます」調を体言止めに変更し、より簡潔で技術文書らしい文体に統一。

## Changes

- **CLAUDE.md**: 6箇所の文末表現を体言止めに変更
  - Line 7: `リポジトリです。...提供します。` → `リポジトリ。...提供。`
  - Line 43: `提供します：` → `提供：`
  - Line 49: `動作します：` → `動作：`
  - Line 62: `含みます。` → `含む。`
  - Line 66: `自動承認されています：` → `自動承認：`
  - Line 76: `自動化することです。` → `自動化。`

- **.claude/settings.local.json**: `Bash(cat:*)` と `Bash(git checkout:*)` を承認済みコマンドに追加

## Test plan

- [x] 全ての「です・ます」調が体言止めに変更されていることを確認
- [x] 文章の意味と明確さが保持されていることを確認
- [x] grepコマンドで残存する「です・ます」がないことを検証

## Related Issue

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)